### PR TITLE
[Fix] Handle submitting while fetching

### DIFF
--- a/src/js/api/ChatAPI.js
+++ b/src/js/api/ChatAPI.js
@@ -12,7 +12,7 @@ var paths = {
 
 var ChatAPI = {
     getRoom : function(){
-        firebaseRef.child(paths.rooms).on('value', 
+        firebaseRef.child(paths.rooms).on('value',
             function(data) {
                 RoomActions.roomFetched(data.val());
             },
@@ -23,7 +23,20 @@ var ChatAPI = {
     },
     submitRoom : function(submitRoom){
         var key = submitRoom.name.toLowerCase();
-        firebaseRef.child(paths.rooms).update({[key] : submitRoom});
+        // https://www.firebase.com/docs/web/guide/saving-data.html#section-completion-callback
+        firebaseRef.child(paths.rooms).update({[key] : submitRoom}, function(error) {
+          if (error) {
+            // One should probably display an error to the user, but for now:
+            console.log('ChatAPI.submitRoom() was unsuccessful: ' + error);
+          } else {
+            console.log('ChatAPI.submitRoom() was successful, updating list of rooms…')
+            // One may either update the list of rooms "locally" by triggering
+            // an action, such as:
+            // RoomActions.roomCreated(submitRoom)
+            // Or, by fetching the full list from Firebase again (safer?):
+            ChatAPI.getRoom();
+          }
+        });
     }
 };
 

--- a/src/js/components/RoomBox.js
+++ b/src/js/components/RoomBox.js
@@ -9,33 +9,33 @@ var RoomBox = React.createClass({
             rooms : RoomStore.getRooms()
         }
     },
-    
+
     componentDidMount : function(){
         RoomStore.addChangeListener(this._onChange);
     },
-    
+
     componentWillUnmount : function(){
         RoomStore.removeChangeListener(this._onChange);
     },
-    
+
     handleSubmitRoom : function(submitRoom){
         RoomActions.submitRoom(submitRoom);
     },
-    
+
     handleCreateRoom : function(newRoom){
         RoomActions.createRoom(newRoom);
     },
-    
+
     handleDeleteRoom : function(deleteRoom){
         RoomActions.deleteRoom(deleteRoom);
     },
-    
+
     _onChange : function() {
         this.setState({
-            rooms : RoomStore.getRooms()
+            rooms: RoomStore.getRooms()
         })
     },
-    
+
     render : function () {
         var roomNodes = this.state.rooms.map(RoomNode.fromObject);
         return (

--- a/src/js/stores/RoomStore.js
+++ b/src/js/stores/RoomStore.js
@@ -7,10 +7,20 @@ var CHANGE_EVENT = 'change';
 
 var _rooms = [];
 
-var setRooms = function(rooms){
+//var setRooms = function(rooms){
+// This is actually an addRooms function:
+var addRooms = function(rooms) {
     for (var key in rooms) {
         _rooms.push(rooms[key]);
     }
+    // It could be refactored to call an addRoom() function, responsible for
+    // doing _rooms.push(room);
+};
+
+// Refreshing the list of rooms is pretty straightforward.
+var refreshRooms = function(rooms) {
+  _rooms = [];
+  addRooms(rooms);
 }
 
 var createRoom = function(newRoom){
@@ -37,7 +47,7 @@ AppDispatcher.register(function(payload) {
     var action = payload.action;
     switch(action.actionType) {
         case AppConstants.ROOMS_FETCHED:
-            setRooms(action.data);
+            refreshRooms(action.data);
             RoomStore.emit(CHANGE_EVENT);
             break;
         case AppConstants.CREATE_ROOM:


### PR DESCRIPTION
The best way to handle a submit while fetching is to actually _not_ handle it :D

Most requests on Firebase can be checked for completion; here, if successful, one simply has to update the list of rooms, either locally (only the UI updates, no Firebase request is triggered) or through an actual refresh (Firebase request, with a side effect of updating the UI once completed). I prefer the latter, for I feel it better constraints the data, but the former may feel more responsive.

If a user loads the page (fetching the rooms) and create a new room that is not persisted before the fetch request is complete, then what will now happen is:

```
[page-load] => fetch => [UI-updated]
       [user-submit] => submit => fetch => [UI-updated]
```

That's two fetch requests in a row, triggered by two different events, but that's quite lightweight (the list of rooms is not that huge, especially since we moved their messages out), and that way the UI is _always_ consistent with the persisted data.
